### PR TITLE
Queue Hook Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ More in-depth information on best practices and how to use operations effectivel
  - [Creating Your First Operation](/docs/first-operation.md)
  - [How to Queue Operations](/docs/queueing.md)
  - [Handling Failures Gracefully](/docs/failing.md)
+ 
+Once you're familiar with using operations, check out some these docs on more advanced features.
+
+ - [Queue Hook Function](/docs/queue-hook.md)
 
 ## License
 

--- a/docs/queue-hook.md
+++ b/docs/queue-hook.md
@@ -1,0 +1,40 @@
+# Queue Hook Function
+
+Before you use the `queue` hook, you need to know about some potential pitfalls you can fall into if you're not careful.
+
+The biggest issue you could run into is making your hook resource intensive. The Operator calls an operation's `queue` function synchronously (if it exists) for every operation that's ready to run. If you make external API calls, the cron job that handles queueing all of your operations will become unbearably slow. The `queue` hook should be reserved for things that you need to happen before an operation is ever placed into the queue.
+
+To avoid most pitfalls, try placing everything into the `run` function and only move it into `queue`  when you have issues with it.
+
+## How it Works
+
+Now that you have an operation where you're certain that the `queue` hook is what you need, we'll dive into how to implement it.
+
+Within your operation's class where you implemented the `run` function, add a `public` `queue` function:
+
+```php
+<?php
+
+namespace App\Operations;
+
+use DealerInspire\Operations\Operation;
+
+class RankUpUserOperation extends Operation
+{
+    public function queue() {
+        // Do whatever you need to do.
+    }
+
+    public function run() { /* ... */ }
+}
+```
+
+Now, whenever the Operator queues a `RankUpUserOperation` it will call your custom `queue` function before it adds the operation to the job queue.
+
+## What Is a Good Use Case?
+
+Keeping `queue` short and sweet is important, so what can you _actually_ do with it?
+
+The most generally applicable use case would be to dispatch an event that your operation has been queued. This is especially useful if you have several unrelated things that need to happen when an operation is queued. Dispatching an event allows your `queue` function to run quickly, ensuring that your Operator doesn't get backed up trying to execute slow functions.
+
+If you use Laravel's [broadcasting](https://laravel.com/docs/5.8/broadcasting) functionality, dispatching a notification to your front-end application when an operation is queued can allow your users to have dynamic insights into processes that they might be waiting for. Dispatching a notification letting them know that an operation has been placed in the queue, and then dispatching more notifications when it runs, can give your users confidence that your application is doing what it says it will do.

--- a/docs/queueing.md
+++ b/docs/queueing.md
@@ -47,4 +47,8 @@ protected function schedule(Schedule $schedule)
 
 _If you do use Laravel's scheduling function, don't forget to [set it up](https://laravel.com/docs/5.8/scheduling#introduction)._
 
+## Hooking into when your operation is queued
+
+If you ever need to do some logic or action while an event is being queued, you can use the `queue` hook function. This function is easy to abuse, so you can read more about what it is and how to avoid some potential pitfalls in [Queue Hook Function](/docs/queue-hook.md).
+
 Next: [Handling Failures Gracefully](/docs/failing.md)

--- a/src/Operator.php
+++ b/src/Operator.php
@@ -13,6 +13,10 @@ final class Operator
                 $operation->started_run_at = Carbon::now();
                 $operation->save();
 
+                if (method_exists($operation, 'queue')) {
+                    $operation->queue();
+                }
+
                 OperationJob::dispatch($operation);
             });
         }

--- a/tests/Operations/ExampleOperation.php
+++ b/tests/Operations/ExampleOperation.php
@@ -8,6 +8,12 @@ class ExampleOperation extends Operation
 {
     protected $hasRun = false;
 
+    public function queue()
+    {
+        $this->hooked_into_queue = true;
+        $this->save();
+    }
+
     public function run()
     {
         $this->hasRun = true;
@@ -16,5 +22,10 @@ class ExampleOperation extends Operation
     public function hasRun(): bool
     {
         return $this->hasRun;
+    }
+
+    public function hookedIntoQueue(): bool
+    {
+        return $this->hooked_into_queue;
     }
 }

--- a/tests/OperatorTest.php
+++ b/tests/OperatorTest.php
@@ -102,4 +102,21 @@ class OperatorTest extends TestCase
 
         $this->assertNull($exampleOperation->fresh()->started_run_at);
     }
+
+    /** @test */
+    public function it_calls_an_operations_queue_event_when_event_is_queued()
+    {
+        $exampleOperation = new ExampleOperation();
+        $exampleOperation->should_run_at = Carbon::now()->subMinutes(5);
+        $exampleOperation->save();
+
+        $pendingOperation = new ExampleOperation();
+        $pendingOperation->should_run_at = Carbon::now()->addMinutes(5);
+        $pendingOperation->save();
+
+        Operator::queue();
+
+        $this->assertTrue($exampleOperation->fresh()->hookedIntoQueue());
+        $this->assertFalse($pendingOperation->fresh()->hookedIntoQueue());
+    }
 }

--- a/tests/database/2019_07_04_000000_create_example_operations_table.php
+++ b/tests/database/2019_07_04_000000_create_example_operations_table.php
@@ -15,6 +15,7 @@ class CreateExampleOperationsTable extends Migration
     {
         Schema::create('example_operations', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->boolean('hooked_into_queue')->default(false);
             $table->timestamp('should_run_at');
             $table->timestamp('started_run_at')->nullable();
             $table->timestamp('finished_run_at')->nullable();


### PR DESCRIPTION
This PR adds the `queue` hook function that will be called right before an operation is placed into the job queue. This allows developers to do things like dispatch events or send notifications to the front-end to do things like start processing related but asynchronous tasks or let the user know that some work is processing in the background for them.

Resolves #7