### PR TITLE
Add dispatch and dispatchNow functionality

### DIFF
--- a/src/Operation.php
+++ b/src/Operation.php
@@ -45,11 +45,11 @@ abstract class Operation extends Model
 
     public static function schedule($shouldRunAt, $attributes = [])
     {
-        static::create(array_merge(['should_run_at' => $shouldRunAt], $attributes));
+        return static::create(array_merge(['should_run_at' => $shouldRunAt], $attributes));
     }
 
     public static function dispatch($attributes = [])
     {
-        static::schedule(Carbon::now(), $attributes);
+        return static::schedule(Carbon::now(), $attributes);
     }
 }

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -52,4 +52,15 @@ abstract class Operation extends Model
     {
         return static::schedule(Carbon::now(), $attributes);
     }
+
+    public static function dispatchNow($attributes = [])
+    {
+        $operation = static::dispatch($attributes);
+
+        $operation->started_run_at = Carbon::now();
+
+        (new OperationJob($operation))->handle();
+
+        return $operation;
+    }
 }

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -2,6 +2,7 @@
 
 namespace DealerInspire\Operations;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use DealerInspire\Operations\Exceptions\OperationStoppedException;
@@ -45,5 +46,10 @@ abstract class Operation extends Model
     public static function schedule($shouldRunAt, $attributes = [])
     {
         static::create(array_merge(['should_run_at' => $shouldRunAt], $attributes));
+    }
+
+    public static function dispatch($attributes = [])
+    {
+        static::schedule(Carbon::now(), $attributes);
     }
 }

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -56,21 +56,19 @@ class OperationTest extends TestCase
     /** @test */
     public function it_can_schedule_itself()
     {
-        ExampleOperation::schedule(Carbon::now()->addDay());
+        $operation = ExampleOperation::schedule(Carbon::now()->addDay());
 
-        $operation = ExampleOperation::first();
         $this->assertEquals(Carbon::now()->addDay(), $operation->should_run_at);
     }
 
     /** @test */
     public function it_can_schedule_itself_with_custom_columns()
     {
-        ColumnOperation::schedule(Carbon::now()->addDay(), [
+        $operation = ColumnOperation::schedule(Carbon::now()->addDay(), [
             'value' => 2500,
             'message' => 'Custom Columns',
         ]);
 
-        $operation = ColumnOperation::first();
         $this->assertEquals(Carbon::now()->addDay(), $operation->should_run_at);
         $this->assertEquals(2500, $operation->value);
         $this->assertEquals('Custom Columns', $operation->message);
@@ -79,21 +77,19 @@ class OperationTest extends TestCase
     /** @test */
     public function it_can_dispatch_itself_which_schedules_it_to_run_now()
     {
-        ExampleOperation::dispatch();
+        $operation = ExampleOperation::dispatch();
 
-        $operation = ExampleOperation::first();
         $this->assertEquals(Carbon::now(), $operation->should_run_at);
     }
 
     /** @test */
     public function it_can_dispatch_itself_to_run_now_with_custom_columns()
     {
-        ColumnOperation::dispatch([
+        $operation = ColumnOperation::dispatch([
             'value' => 5000,
             'message' => 'Dispatching Operations',
         ]);
 
-        $operation = ColumnOperation::first();
         $this->assertEquals(Carbon::now(), $operation->should_run_at);
         $this->assertEquals(5000, $operation->value);
         $this->assertEquals('Dispatching Operations', $operation->message);

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -94,4 +94,37 @@ class OperationTest extends TestCase
         $this->assertEquals(5000, $operation->value);
         $this->assertEquals('Dispatching Operations', $operation->message);
     }
+
+    /** @test */
+    public function it_can_dispatch_itself_concurrently()
+    {
+        $operation = ExampleOperation::dispatchNow();
+
+        $this->assertTrue($operation->hasRun());
+
+        // Ensure that the database record has all of the timestamps set correctly.
+        $operation = ExampleOperation::first();
+        $this->assertEquals(Carbon::now(), $operation->should_run_at);
+        $this->assertEquals(Carbon::now(), $operation->started_run_at);
+        $this->assertEquals(Carbon::now(), $operation->finished_run_at);
+    }
+
+    /** @test */
+    public function it_can_dispatch_itself_concurrently_with_custom_columns()
+    {
+        $operation = ColumnOperation::dispatchNow([
+            'value' => 1234,
+            'message' => 'Concurrency',
+        ]);
+
+        $this->assertTrue($operation->hasRun());
+
+        // Ensure that the database record has all of the timestamps set correctly.
+        $operation = ColumnOperation::first();
+        $this->assertEquals(Carbon::now(), $operation->should_run_at);
+        $this->assertEquals(Carbon::now(), $operation->started_run_at);
+        $this->assertEquals(Carbon::now(), $operation->finished_run_at);
+        $this->assertEquals(1234, $operation->value);
+        $this->assertEquals('Concurrency', $operation->message);
+    }
 }

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -75,4 +75,27 @@ class OperationTest extends TestCase
         $this->assertEquals(2500, $operation->value);
         $this->assertEquals('Custom Columns', $operation->message);
     }
+
+    /** @test */
+    public function it_can_dispatch_itself_which_schedules_it_to_run_now()
+    {
+        ExampleOperation::dispatch();
+
+        $operation = ExampleOperation::first();
+        $this->assertEquals(Carbon::now(), $operation->should_run_at);
+    }
+
+    /** @test */
+    public function it_can_dispatch_itself_to_run_now_with_custom_columns()
+    {
+        ColumnOperation::dispatch([
+            'value' => 5000,
+            'message' => 'Dispatching Operations',
+        ]);
+
+        $operation = ColumnOperation::first();
+        $this->assertEquals(Carbon::now(), $operation->should_run_at);
+        $this->assertEquals(5000, $operation->value);
+        $this->assertEquals('Dispatching Operations', $operation->message);
+    }
 }

--- a/tests/Operations/ColumnOperation.php
+++ b/tests/Operations/ColumnOperation.php
@@ -6,8 +6,15 @@ use DealerInspire\Operations\Operation;
 
 class ColumnOperation extends Operation
 {
+    protected $hasRun = false;
+
     public function run()
     {
-        //
+        $this->hasRun = true;
+    }
+
+    public function hasRun(): bool
+    {
+        return $this->hasRun;
     }
 }


### PR DESCRIPTION
This PR resolves #4 by adding `dispatch` and `dispatchNow` functions to the Operation class.

`dispatch` is mostly a helper function which just proxies the call to the `schedule` with `Carbon::now()` as the `should_run_at` timestamp so that it will run as soon as you call `queue` on the Operator class.

`dispatchNow` creates an operation, but also dispatches a job synchronously to process that operation, so that by the time the result of `dispatchNow` comes back the operation has been fully run (assuming no exceptions are thrown).