### PR TITLE
Custom queues and connections for operations

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -22,3 +22,26 @@ class HighPriorityQueueOperation extends Operation
     }
 }
 ```
+
+## `queueConnection` Property
+
+If you have multiple queue connections in your app, some operations may need to run on different connections. You can specify a `public $queueConnection`
+property on your operation, the value of which will be used to specify the name of the connection it will run on.
+
+```php
+<?php
+
+namespace App\Operations;
+
+use DealerInspire\Operations\Operation;
+
+class RedisQueueOperation extends Operation
+{
+    public $queueConnection = 'redis';
+
+    public function run()
+    {
+        //
+    }
+}
+```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,24 @@
+# Advanced Usage
+
+## `queue` Property
+
+If you have multiple queues in your app, some operations may need to run on a few of these queues. You can specify a `public $queue` property on your operation,
+the value of which will be used to specify the name of the queue it will run on.
+
+```php
+<?php
+
+namespace App\Operations;
+
+use DealerInspire\Operations\Operation;
+
+class HighPriorityQueueOperation extends Operation
+{
+    public $queue = 'high-priority';
+
+    public function run()
+    {
+        //
+    }
+}
+```

--- a/docs/failing.md
+++ b/docs/failing.md
@@ -25,3 +25,5 @@ If an unhandled exception is encountered, the operation job will retry up to wha
 If the operation job was not able to successfully run the operation and an exception is still being thrown, your operation will become **stuck**. This simply means that the operation has a `started_run_at` timestamp set but it is not actually being run. Because the Operator will not start running an operation that has a `should_run_at` timestamp set, the operation will never finish running.
 
 This is why it is important to properly `stop()` or `cancel()` an operation if you are aware of an error case that you want to handle automatically.
+
+Next: [Advanced Usage](/docs/advanced.md)

--- a/src/Operator.php
+++ b/src/Operator.php
@@ -17,10 +17,14 @@ final class Operator
                     $operation->queue();
                 }
 
+                $operationJob = Operationjob::dispatch($operation);
+
                 if (property_exists($operation, 'queue')) {
-                    OperationJob::dispatch($operation)->onQueue($operation->queue);
-                } else {
-                    OperationJob::dispatch($operation);
+                    $operationJob->onQueue($operation->queue);
+                }
+
+                if (property_exists($operation, 'queueConnection')) {
+                    $operationJob->onConnection($operation->queueConnection);
                 }
             });
         }

--- a/src/Operator.php
+++ b/src/Operator.php
@@ -17,7 +17,11 @@ final class Operator
                     $operation->queue();
                 }
 
-                OperationJob::dispatch($operation);
+                if (property_exists($operation, 'queue')) {
+                    OperationJob::dispatch($operation)->onQueue($operation->queue);
+                } else {
+                    OperationJob::dispatch($operation);
+                }
             });
         }
     }

--- a/tests/Operations/CustomConnectionOperation.php
+++ b/tests/Operations/CustomConnectionOperation.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DealerInspire\Operations\Tests\Operations;
+
+use DealerInspire\Operations\Operation;
+
+class CustomConnectionOperation extends Operation
+{
+    public $queueConnection = 'custom';
+
+    public function run()
+    {
+        //
+    }
+}

--- a/tests/Operations/CustomQueueOperation.php
+++ b/tests/Operations/CustomQueueOperation.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DealerInspire\Operations\Tests\Operations;
+
+use DealerInspire\Operations\Operation;
+
+class CustomQueueOperation extends Operation
+{
+    public $queue = 'custom';
+
+    public function run()
+    {
+        //
+    }
+}

--- a/tests/OperatorTest.php
+++ b/tests/OperatorTest.php
@@ -3,6 +3,7 @@
 namespace DealerInspire\Operations\Tests;
 
 use Carbon\Carbon;
+use DealerInspire\Operations\Tests\Operations\CustomConnectionOperation;
 use DealerInspire\Operations\Tests\Operations\CustomQueueOperation;
 use Illuminate\Support\Facades\Queue;
 use DealerInspire\Operations\OperationJob;
@@ -70,6 +71,19 @@ class OperatorTest extends TestCase
         Queue::assertPushedOn('custom', OperationJob::class);
         Queue::assertPushed(OperationJob::class, function (OperationJob $job) use ($customQueueOperation) {
             return $job->getOperation()->is($customQueueOperation);
+        });
+    }
+
+    /** @test */
+    public function it_runs_operations_with_a_custom_connection_on_the_custom_connection_when_scheduled_and_queued()
+    {
+        $customConnectionOperation = CustomConnectionOperation::schedule(Carbon::now()->subMinutes(5));
+
+        Operator::queue();
+
+        Queue::assertPushed(OperationJob::class, function (OperationJob $job) use ($customConnectionOperation) {
+            return $job->connection === 'custom'
+                && $job->getOperation()->is($customConnectionOperation);
         });
     }
 

--- a/tests/OperatorTest.php
+++ b/tests/OperatorTest.php
@@ -3,6 +3,7 @@
 namespace DealerInspire\Operations\Tests;
 
 use Carbon\Carbon;
+use DealerInspire\Operations\Tests\Operations\CustomQueueOperation;
 use Illuminate\Support\Facades\Queue;
 use DealerInspire\Operations\OperationJob;
 use DealerInspire\Operations\Facades\Operator;
@@ -57,6 +58,19 @@ class OperatorTest extends TestCase
         $this->assertNotNull($exampleOperation->fresh()->started_run_at);
         $this->assertNotNull($firstAnotherOperation->fresh()->started_run_at);
         $this->assertNotNull($secondAnotherOperation->fresh()->started_run_at);
+    }
+
+    /** @test */
+    public function it_runs_operations_with_a_custom_queue_on_the_custom_queue_when_scheduled_and_queued()
+    {
+        $customQueueOperation = CustomQueueOperation::schedule(Carbon::now()->subMinutes(5));
+
+        Operator::queue();
+
+        Queue::assertPushedOn('custom', OperationJob::class);
+        Queue::assertPushed(OperationJob::class, function (OperationJob $job) use ($customQueueOperation) {
+            return $job->getOperation()->is($customQueueOperation);
+        });
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace DealerInspire\Operations\Tests;
 
 use Carbon\Carbon;
+use DealerInspire\Operations\Tests\Operations\CustomQueueOperation;
 use Illuminate\Support\Facades\Queue;
 use DealerInspire\Operations\OperationServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
@@ -26,6 +27,7 @@ class TestCase extends OrchestraTestCase
         $app['config']->set('operations.operations', [
             ExampleOperation::class,
             AnotherOperation::class,
+            CustomQueueOperation::class,
         ]);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace DealerInspire\Operations\Tests;
 
 use Carbon\Carbon;
+use DealerInspire\Operations\Tests\Operations\CustomConnectionOperation;
 use DealerInspire\Operations\Tests\Operations\CustomQueueOperation;
 use Illuminate\Support\Facades\Queue;
 use DealerInspire\Operations\OperationServiceProvider;
@@ -28,6 +29,7 @@ class TestCase extends OrchestraTestCase
             ExampleOperation::class,
             AnotherOperation::class,
             CustomQueueOperation::class,
+            CustomConnectionOperation::class,
         ]);
     }
 

--- a/tests/database/2020_03_20_000000_create_custom_connection_operations_table.php
+++ b/tests/database/2020_03_20_000000_create_custom_connection_operations_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateCustomConnectionOperationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('custom_connection_operations', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamp('should_run_at');
+            $table->timestamp('started_run_at')->nullable();
+            $table->timestamp('finished_run_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('custom_connection_operations');
+    }
+}

--- a/tests/database/2020_03_20_000000_create_custom_queue_operations_table.php
+++ b/tests/database/2020_03_20_000000_create_custom_queue_operations_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateCustomQueueOperationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('custom_queue_operations', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamp('should_run_at');
+            $table->timestamp('started_run_at')->nullable();
+            $table->timestamp('finished_run_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('custom_queue_operations');
+    }
+}


### PR DESCRIPTION
This PR adds the ability to specify which connection and/or which queue your operations will be run on.

Add `public $queue = 'custom-queue-name'` to run your operations on the `custom-queue-name` queue.

Add `public $queueConnection = 'custom-connection-name'` to run your operations on the `custom-connection-name` connection.

Closes #3 