### PR TITLE
Add custom tags support

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -45,3 +45,33 @@ class RedisQueueOperation extends Operation
     }
 }
 ```
+
+## Custom Horizon Tags
+
+By default, operations are tagged with `operation` and `{Operation::class}:{id}`, which are used by Horizon to give you the ability to better track the operations
+that your system is processing. If you want to define your own custom tags, override the `tags()` function and return an array of strings. These strings will be
+the tags you see in Horizon.
+
+```php
+<?php
+
+namespace App\Operations;
+
+use DealerInspire\Operations\Operation;
+
+class TaggedOperation extends Operation
+{
+    public function run()
+    {
+        //
+    }
+
+    public function tags()
+    {
+        return [
+            'custom-tags',
+            'foobar',
+        ];
+    }
+}
+```

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -63,4 +63,12 @@ abstract class Operation extends Model
 
         return $operation;
     }
+
+    public function tags()
+    {
+        return [
+            'operation',
+            static::class.':'.$this->id,
+        ];
+    }
 }

--- a/src/OperationJob.php
+++ b/src/OperationJob.php
@@ -52,7 +52,6 @@ class OperationJob implements ShouldQueue
 
     public function tags()
     {
-        $uniqueTag = get_class($this->operation).':'.$this->operation->id;
-        return ['operation', $uniqueTag];
+        return $this->operation->tags();
     }
 }

--- a/tests/OperationJobTest.php
+++ b/tests/OperationJobTest.php
@@ -9,6 +9,7 @@ use DealerInspire\Operations\Tests\Operations\ExampleOperation;
 use DealerInspire\Operations\Tests\Operations\StoppingOperation;
 use DealerInspire\Operations\Tests\Operations\CancelingOperation;
 use DealerInspire\Operations\Tests\Operations\DependantOperation;
+use DealerInspire\Operations\Tests\Operations\TaggedOperation;
 
 class OperationJobTest extends TestCase
 {
@@ -122,5 +123,21 @@ class OperationJobTest extends TestCase
             AnotherOperation::class.':456',
         ];
         $this->assertSame($expectedAnotherTags, $anotherOperationJob->tags());
+    }
+
+    /** @test */
+    public function it_uses_custom_tags_from_operation_instead_of_default_tags()
+    {
+        $taggedOperation = new TaggedOperation();
+        $taggedOperation->id = 123;
+        $taggedOperationJob = new OperationJob($taggedOperation);
+
+        $expectedTags = [
+            'custom-tags',
+            'foobar',
+            'tagged',
+        ];
+
+        $this->assertSame($expectedTags, $taggedOperationJob->tags());
     }
 }

--- a/tests/Operations/TaggedOperation.php
+++ b/tests/Operations/TaggedOperation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DealerInspire\Operations\Tests\Operations;
+
+use DealerInspire\Operations\Operation;
+
+class TaggedOperation extends Operation
+{
+    public function run()
+    {
+        //
+    }
+
+    public function tags()
+    {
+        return [
+            'custom-tags',
+            'foobar',
+            'tagged',
+        ];
+    }
+}

--- a/tests/database/2020_03_20_000000_create_tagged_operations_table.php
+++ b/tests/database/2020_03_20_000000_create_tagged_operations_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTaggedOperationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tagged_operations', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamp('should_run_at');
+            $table->timestamp('started_run_at')->nullable();
+            $table->timestamp('finished_run_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tagged_operations');
+    }
+}


### PR DESCRIPTION
This PR adds custom tags support. If you override the `tags()` function on your operation, the array of strings that it returns will be used as the tags shown in tools like Laravel Horizon.

Closes #9 