### PR TITLE
Update the laravel dependency to include laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2.5",
-        "laravel/framework": "^7.0"
+        "laravel/framework": "^7.0|^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0"


### PR DESCRIPTION
From my testing this seems to be the only thing keeping this package at Laravel v7. I didn't run through any kind of upgrade guide though :sweat_smile: 